### PR TITLE
Feat combat hotkeys

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
 	<script src="script/space.js"></script>
 	<script src="script/prestige.js"></script>
 	<script src="script/scoring.js"></script>
+	<script src="script/combatcontrol.js"></script>
 	<!-- Event modules -->
 	<script src="script/events/global.js"></script>
 	<script src="script/events/room.js"></script>

--- a/script/combatcontrol.js
+++ b/script/combatcontrol.js
@@ -14,6 +14,30 @@ var combatKeys = {
     'thrust' : {
         'keyCode' : 114,
         'text' : '[R]'
+    },
+    'eat': {
+        'keyCode': 49,
+        'text': '[1]'
+    },
+    'meds': {
+        'keyCode': 50,
+        'text': '[2]'
+    },
+    'shoot': {
+        'keyCode': 97,
+        'text': '[A]'
+    },
+    'blast': {
+        'keyCode': 115,
+        'text': '[S]'
+    },
+    'lob': {
+        'keyCode': 100,
+        'text': '[D]'
+    },
+    'tangle': {
+        'keyCode': 102,
+        'text': '[F]'
     }
 }
 
@@ -35,6 +59,24 @@ function bindCombatKeys() {
             case combatKeys.thrust.keyCode:
                 console.log("Button " + combatKeys.thrust.text + " pressed");
                 $("#attack_bayonet").trigger("click");
+                break;
+            case combatKeys.eat.keyCode:
+                $("#eat").trigger("click");
+                break;
+            case combatKeys.meds.keyCode:
+                $("#meds").trigger("click");
+                break;
+            case combatKeys.shoot.keyCode:
+                $("#attack_rifle").trigger("click");
+                break;
+            case combatKeys.blast.keyCode:
+                $("#attack_laser-rifle").trigger("click");
+                break;
+            case combatKeys.lob.keyCode:
+                $("#attack_grenade").trigger("click");
+                break;
+            case combatKeys.tangle.keyCode:
+                $("#attack_bolas").trigger("click");
                 break;
         }
     })

--- a/script/combatcontrol.js
+++ b/script/combatcontrol.js
@@ -17,11 +17,11 @@ var combatKeys = {
     },
     'eat': {
         'keyCode': 49,
-        'text': '[1]'
+        'text': '[num 1]'
     },
     'meds': {
         'keyCode': 50,
-        'text': '[2]'
+        'text': '[num 2]'
     },
     'shoot': {
         'keyCode': 97,

--- a/script/combatcontrol.js
+++ b/script/combatcontrol.js
@@ -45,19 +45,15 @@ function bindCombatKeys() {
     $('body').bind('keypress.combat', function(e) {
         switch(e.keyCode){
             case combatKeys.stab.keyCode:
-                console.log("Button " + combatKeys.stab.text + " pressed");
                 $("#attack_bone-spear").trigger("click");
                 break;
             case combatKeys.swing.keyCode:
-                console.log("Button " + combatKeys.swing.text + " pressed");
                 $("#attack_iron-sword").trigger("click");
                 break;
             case combatKeys.slash.keyCode:
-                console.log("Button " + combatKeys.slash.text + " pressed");
                 $("#attack_steel-sword").trigger("click");
                 break;
             case combatKeys.thrust.keyCode:
-                console.log("Button " + combatKeys.thrust.text + " pressed");
                 $("#attack_bayonet").trigger("click");
                 break;
             case combatKeys.eat.keyCode:

--- a/script/combatcontrol.js
+++ b/script/combatcontrol.js
@@ -1,0 +1,45 @@
+var combatKeys = {
+    'stab' : {
+        'keyCode' : 113,
+        'text' : '[Q]'
+    },
+    'swing' : {
+        'keyCode' : 119,
+        'text' : '[W]'
+    },
+    'slash' : {
+        'keyCode' : 101,
+        'text' : '[E]'
+    },
+    'thrust' : {
+        'keyCode' : 114,
+        'text' : '[R]'
+    }
+}
+
+function bindCombatKeys() {
+    $('body').bind('keypress.combat', function(e) {
+        switch(e.keyCode){
+            case combatKeys.stab.keyCode:
+                console.log("Button " + combatKeys.stab.text + " pressed");
+                $("#attack_bone-spear").trigger("click");
+                break;
+            case combatKeys.swing.keyCode:
+                console.log("Button " + combatKeys.swing.text + " pressed");
+                $("#attack_iron-sword").trigger("click");
+                break;
+            case combatKeys.slash.keyCode:
+                console.log("Button " + combatKeys.slash.text + " pressed");
+                $("#attack_steel-sword").trigger("click");
+                break;
+            case combatKeys.thrust.keyCode:
+                console.log("Button " + combatKeys.thrust.text + " pressed");
+                $("#attack_bayonet").trigger("click");
+                break;
+        }
+    })
+}
+
+function unbindCombatKeys() {
+    $('body').unbind('keypress.combat');
+}

--- a/script/events.js
+++ b/script/events.js
@@ -138,6 +138,8 @@ var Events = {
 
 		// Set up the enemy attack timer
 		Events._enemyAttackTimer = Engine.setInterval(Events.enemyAttack, scene.attackDelay * 1000);
+
+		bindCombatKeys();
 	},
 
 	setPause: function(btn, state){
@@ -528,6 +530,7 @@ var Events = {
 		Events.fought = true;
 		clearTimeout(Events._enemyAttackTimer);
 		Events.removePause($('#pause'), 'end');
+		unbindCombatKeys();
 	},
 
 	winFight: function() {

--- a/script/events.js
+++ b/script/events.js
@@ -230,7 +230,7 @@ var Events = {
 
 		var btn = new Button.Button({
 			id: 'eat',
-			text: _('eat meat'),
+			text: _('eat meat ' + combatKeys.eat.text),
 			cooldown: cooldown,
 			click: Events.eatMeat,
 			cost: { 'cured meat': 1 }
@@ -250,7 +250,7 @@ var Events = {
 
 		var btn = new Button.Button({
 			id: 'meds',
-			text: _('use meds'),
+			text: _('use meds ' + combatKeys.meds.text),
 			cooldown: cooldown,
 			click: Events.useMeds,
 			cost: { 'medicine': 1 }
@@ -273,7 +273,7 @@ var Events = {
 		}
 		var btn = new Button.Button({
 			id: 'attack_' + weaponName.replace(' ', '-'),
-			text: weapon.verb,
+			text: weapon.verb + ' ' + combatKeys[weapon.verb].text,
 			cooldown: cd,
 			click: Events.useWeapon,
 			cost: weapon.cost

--- a/script/events.js
+++ b/script/events.js
@@ -530,7 +530,6 @@ var Events = {
 		Events.fought = true;
 		clearTimeout(Events._enemyAttackTimer);
 		Events.removePause($('#pause'), 'end');
-		unbindCombatKeys();
 	},
 
 	winFight: function() {
@@ -1097,6 +1096,7 @@ var Events = {
 			// Force refocus on the body. I hate you, IE.
 			$('body').focus();
 		});
+		unbindCombatKeys();
 	},
 
 	handleStateUpdates: function(e){


### PR DESCRIPTION
Added combat control script that bind action to key as listed below:

1. stab to Q 
2. swing to W
3. slash to E
4. thrust to R
5. shoot to A
6. blast to S
7. lob to D
8. tangle to F
9. eat meat to num 1
10. use meds to num 2